### PR TITLE
Add backend docker as extra host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: docker/dev/Dockerfile
+    environment:
+      BACKEND_URL: http://mitra-backend:1337
     extra_hosts:
       - "mitra-backend:172.17.0.1"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: docker/dev/Dockerfile
+    extra_hosts:
+      - "mitra-backend:172.17.0.1"
     volumes:
       - ".:/app"
       - "/app/node_modules"

--- a/vue.config.js
+++ b/vue.config.js
@@ -11,6 +11,6 @@ module.exports = {
     }
   },
   devServer: {
-    proxy: "http://localhost:1337"
+    proxy: "http://mitra-backend:1337"
   }
 };

--- a/vue.config.js
+++ b/vue.config.js
@@ -11,6 +11,6 @@ module.exports = {
     }
   },
   devServer: {
-    proxy: "http://mitra-backend:1337"
+    proxy: process.env.BACKEND_URL
   }
 };


### PR DESCRIPTION
These are changes I need to make to run frontend and backend successfully in docker. Although this makes it impossible to run the frontend without docker. 

What do we want to do about it? maybe make `dev-server.proxy` as an ENV variable could solve the problem. 
So that we can start the frontend something likes this: `BACKEND_URL=http://mitra-backend:1337 npm run serve`